### PR TITLE
Implement an INEXACT_OBJECT type.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "namebase-types",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namebase-types",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Check types at runtime.",
   "main": "./src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ function ENUM(...values) {
   };
 }
 
-function OBJECT(template) {
+function OBJECT(template, throwOnExtraKeys = true) {
   return function(x) {
     // make sure x is even an object
     if (!x || x.constructor !== Object) {
@@ -81,13 +81,15 @@ function OBJECT(template) {
       }
     });
 
-    // check for extra keys
-    const keysInTemplate = new Set(Object.keys(template));
-    const extraKeys = Object.keys(x).filter(key => {
-      return !keysInTemplate.has(key);
-    });
-    if (extraKeys.length > 0) {
-      errors.push(new exceptions.ExtraKey(extraKeys[0])); // the first extra
+    if (throwOnExtraKeys) {
+      // check for extra keys
+      const keysInTemplate = new Set(Object.keys(template));
+      const extraKeys = Object.keys(x).filter(key => {
+        return !keysInTemplate.has(key);
+      });
+      if (extraKeys.length > 0) {
+        errors.push(new exceptions.ExtraKey(extraKeys[0])); // the first extra
+      }
     }
 
     if (errors.length === 0) {
@@ -98,10 +100,9 @@ function OBJECT(template) {
   };
 }
 
-function PARTIAL_OBJECT(template) {
-  return function(x) {
-    throw new exceptions.InvalidType('ROOT');
-  };
+function INEXACT_OBJECT(template) {
+  const throwOnExtraKeys = false;
+  return OBJECT(template, throwOnExtraKeys);
 }
 
 function OR(...options) {
@@ -163,12 +164,12 @@ module.exports = {
   BOOLEAN,
   BOOLEAN_STRING,
   ENUM,
+  INEXACT_OBJECT,
   INTEGER,
   INTEGER_STRING,
   OBJECT,
   OPTIONAL,
   OR,
-  PARTIAL_OBJECT,
   STRING,
   exceptions,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -98,6 +98,12 @@ function OBJECT(template) {
   };
 }
 
+function PARTIAL_OBJECT(template) {
+  return function(x) {
+    throw new exceptions.InvalidType('ROOT');
+  };
+}
+
 function OR(...options) {
   return function(x) {
     const errors = [];
@@ -162,6 +168,7 @@ module.exports = {
   OBJECT,
   OPTIONAL,
   OR,
+  PARTIAL_OBJECT,
   STRING,
   exceptions,
 };

--- a/test/index.js
+++ b/test/index.js
@@ -5,12 +5,12 @@ const {
   BOOLEAN,
   BOOLEAN_STRING,
   ENUM,
+  INEXACT_OBJECT,
   INTEGER,
   INTEGER_STRING,
   OBJECT,
   OPTIONAL,
   OR,
-  INEXACT_OBJECT,
   STRING,
 } = require('../src/index');
 
@@ -401,7 +401,7 @@ describe('namebase-types', () => {
   // Tests specific to INEXACT_OBJECT
   describe('.INEXACT_OBJECT(template)', () => {
     it('should pass a simple, inexact template with mixed types', () => {
-      const parse = PRIMITIVE({
+      const parse = INEXACT_OBJECT({
         a: STRING,
         b: INTEGER,
         c: BOOLEAN,
@@ -416,7 +416,7 @@ describe('namebase-types', () => {
     });
 
     it('should pass a simple, inexact template with optional keys', () => {
-      const parse = PRIMITIVE({
+      const parse = INEXACT_OBJECT({
         a: STRING,
         b: OPTIONAL(INTEGER),
       });
@@ -430,13 +430,13 @@ describe('namebase-types', () => {
     });
 
     it('should fail a simple, inexact template with wrong optional type', () => {
-      const parse = PRIMITIVE({
+      const parse = INEXACT_OBJECT({
         a: STRING,
         b: OPTIONAL(INTEGER),
       });
       expectException(
         () => {
-          parse({ a: 'hello', b: 'there' });
+          parse({ a: 'hello', b: 'there', c: 'extra' });
         },
         'InvalidType',
         'b'

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ const {
   OBJECT,
   OPTIONAL,
   OR,
-  PARTIAL_OBJECT,
+  INEXACT_OBJECT,
   STRING,
 } = require('../src/index');
 
@@ -245,9 +245,9 @@ describe('namebase-types', () => {
     });
   });
 
-  // Tests shared with OBJECT and PARTIAL_OBJECT
-  describe('.OBJECT(template) and .PARTIAL_OBJECT(template)', () => {
-    [OBJECT, PARTIAL_OBJECT].forEach(PRIMITIVE => {
+  // Tests shared with OBJECT and INEXACT_OBJECT
+  describe('.OBJECT(template) and .INEXACT_OBJECT(template)', () => {
+    [OBJECT, INEXACT_OBJECT].forEach(PRIMITIVE => {
       it(`${PRIMITIVE.name}: should pass a simple, exact template with mixed types`, () => {
         const parse = PRIMITIVE({
           a: STRING,
@@ -398,8 +398,8 @@ describe('namebase-types', () => {
     });
   });
 
-  // Tests specific to PARTIAL_OBJECT
-  describe('.PARTIAL_OBJECT(template)', () => {
+  // Tests specific to INEXACT_OBJECT
+  describe('.INEXACT_OBJECT(template)', () => {
     it('should pass a simple, inexact template with mixed types', () => {
       const parse = PRIMITIVE({
         a: STRING,

--- a/test/index.js
+++ b/test/index.js
@@ -399,8 +399,49 @@ describe('namebase-types', () => {
   });
 
   // Tests specific to PARTIAL_OBJECT
-  describe(`.PARTIAL_OBJECT(template)`, () => {
-    // TODO
+  describe('.PARTIAL_OBJECT(template)', () => {
+    it('should pass a simple, inexact template with mixed types', () => {
+      const parse = PRIMITIVE({
+        a: STRING,
+        b: INTEGER,
+        c: BOOLEAN,
+        d: ENUM(100, 200, 300),
+      });
+      const parsedX = parse({ a: 'hello', b: 10, c: true, d: 200, e: 'extra' });
+      assert(Object.keys(parsedX).length === 4);
+      assert(parsedX.a === 'hello');
+      assert(parsedX.b === 10);
+      assert(parsedX.c === true);
+      assert(parsedX.d === 200);
+    });
+
+    it('should pass a simple, inexact template with optional keys', () => {
+      const parse = PRIMITIVE({
+        a: STRING,
+        b: OPTIONAL(INTEGER),
+      });
+      const parsedX = parse({ a: 'hello', b: 10, c: 'extra' });
+      const parsedY = parse({ a: 'hello', c: 'extra' });
+      assert(Object.keys(parsedX).length === 2);
+      assert(parsedX.a === 'hello');
+      assert(parsedX.b === 10);
+      assert(Object.keys(parsedY).length === 1);
+      assert(parsedX.a === 'hello');
+    });
+
+    it('should fail a simple, inexact template with wrong optional type', () => {
+      const parse = PRIMITIVE({
+        a: STRING,
+        b: OPTIONAL(INTEGER),
+      });
+      expectException(
+        () => {
+          parse({ a: 'hello', b: 'there' });
+        },
+        'InvalidType',
+        'b'
+      );
+    });
   });
 
   describe('.OR(...options)', () => {


### PR DESCRIPTION
This has the same implementation as `OBJECT` but it does not throw on extra keys. Shares tests lots of tests with the normal `OBJECT` type, but excludes some tests and adds others.